### PR TITLE
Adding Scoper Feature to SVT

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ $ recon RVA-123 web_services -f test-data/10-ips.txt
 You can pass a domain in the ```subdomains``` option using the ```-d``` or the ```--domain``` flag
 
 ```commandline
-$ python recon.py RVA-123 subdomains -d aldi.us
+$ recon RVA-123 subdomains -d aldi.us
 aldi.us
 mobile.wfm.aldi.us
 gateway.aldi.us

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ The executable file for SVT is ```$HOME/.local/bin/recon```. Using the ```recon 
 
 ```commandline
 $ recon -h
-usage: recon [-h] assessment_id {verify_ip,verify_domain,web_services,subdomains} ...
+usage: recon [-h] assessment_id {scoper,verify_ip,verify_domain,web_services,subdomains} ...
 
 Scoping Validation Tool
 
 positional arguments:
-  assessment_id         The Assessement ID - this is required
+  assessment_id         The Assessment ID - this is required
   {scoper,verify_ip,verify_domain,web_services,subdomains}
     scoper              -f, --file (A File that contains IP's in CIDR notation
     verify_ip           -i, --ip (A single IP to be verified) OR -f, --file (A File that

--- a/README.md
+++ b/README.md
@@ -53,7 +53,23 @@ optional arguments:
   -h, --help            show this help message and exit
 ```
 
-## Menu Option: scoper 
+## Menu Option: scoper
+**Objective:** The purpose of this option is to take a file of IP's in CIDR notation and output a file containing a full list of IP's. 
+This can be helpful as the Scoping Validation Tool only accepts a list of IP's which are not in CIDR notation.
+
+```scoper``` takes a file of IP's in CIDR notation and outputs the full list of IP's in that range.
+
+Output File: ./{assessment_id}_Scoper.txt"
+
+Input File: List of ips in CIDR notation, where each item is entered line by line with no commas separating them
+
+##### Example On How to Run With a File That Contains IPs in CIDR notation:
+
+You can pass a file in the ```scoper``` option using the ```-f``` or the ```--file``` flag
+
+```commandline
+$ recon RVA-123 scoper -f File_With_CIDR_IPs.txt
+```
 
 ## Menu Option: verify_ip 
 **Objective:** The purpose of this option is to validate the scope of an IP or IPs entered by extracting information from *Whois* 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Scoping Validation Tool
 
 positional arguments:
   assessment_id         The Assessement ID - this is required
-  {verify_ip,verify_domain,web_services,subdomains}
+  {scoper,verify_ip,verify_domain,web_services,subdomains}
+    scoper              -f, --file (A File that contains IP's in CIDR notation
     verify_ip           -i, --ip (A single IP to be verified) OR -f, --file (A File that
                         contains a list of ips to be verified)
     verify_domain       -d, --domain (A single domain to be verified) OR -f, --file (A File that
@@ -51,6 +52,8 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
 ```
+
+## Menu Option: scoper 
 
 ## Menu Option: verify_ip 
 **Objective:** The purpose of this option is to validate the scope of an IP or IPs entered by extracting information from *Whois* 

--- a/recon/recon.py
+++ b/recon/recon.py
@@ -441,7 +441,7 @@ def main():
 
     # creating sub parsers
     subparser = parser.add_subparsers(dest='cmd')
-    scoper_parser = subparser.add_parser('scoper', help="Scoping subcommand")
+    scoper_parser = subparser.add_parser('scoper', help="-f, --file (A File that contains IP's in CIDR notation)")
     verify_ip = subparser.add_parser('verify_ip', help="-i, --ip  (A single IP to be verified) "
                                                        "OR -f, --file (A File that contains a "
                                                        "list of ips to be verified)")

--- a/recon/recon.py
+++ b/recon/recon.py
@@ -109,6 +109,8 @@ def scoper(assessment_id, file):
         with open(output_file, "w") as out_f:
             out_f.write(grep_result)
 
+        print(f'\n{Bcolors.OKBLUE}File was outputed in the current working directory to: {assessment_id}_Scoper.txt{Bcolors.ENDC}')
+
     except subprocess.CalledProcessError as e:
         print(f"Error executing command: {e}")
 

--- a/recon/recon.py
+++ b/recon/recon.py
@@ -68,6 +68,46 @@ def country_message(query, country, message=''):
     else:
         print(f"{Bcolors.WARNING} {query} could not determine location. Country extracted is None.{Bcolors.ENDC}\n")
 
+def scoper(assessment_id, file):
+    if file is None:
+        raise ValueError("File cannot be None")
+
+    file_path = file.name  # Extract filename
+    output_file = f"{assessment_id}_InScope.txt"
+
+    try:
+        # Run nmap and capture output
+        nmap_result = subprocess.run(
+            ["nmap", "-Pn", "-n", "-sL", "-iL", file_path], 
+            stdout=subprocess.PIPE, 
+            text=True, 
+            check=True
+        ).stdout
+
+        # Process output with cut
+        cut_result = subprocess.run(
+            ["cut", "-d", " ", "-f", "5"],
+            input=nmap_result,  # Pass as string
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True
+        ).stdout
+
+        # Remove unwanted lines using grep
+        grep_result = subprocess.run(
+            ["grep", "-v", "nmap\|address"],
+            input=cut_result,  # Pass as string
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True
+        ).stdout
+
+        # Write final output to the file
+        with open(output_file, "w") as out_f:
+            out_f.write(grep_result)
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing command: {e}")
 
 def verify_ip_address(assessment_id, ip=None, file=None):
     """ This function takes in an IP or a file listed with IPs and outputs a file that contains the
@@ -401,6 +441,7 @@ def main():
 
     # creating sub parsers
     subparser = parser.add_subparsers(dest='cmd')
+    scoper_parser = subparser.add_parser('scoper', help="Scoping subcommand")
     verify_ip = subparser.add_parser('verify_ip', help="-i, --ip  (A single IP to be verified) "
                                                        "OR -f, --file (A File that contains a "
                                                        "list of ips to be verified)")
@@ -418,6 +459,8 @@ def main():
     subdomains = subdomains.add_mutually_exclusive_group()
 
     # arguments for every subparser
+    scoper_parser.add_argument('-f', '--file', type=argparse.FileType('r'), required=True,
+                               help='A file that contains a list of IPs to be verified')
     verify_ip.add_argument('-i', '--ip', type=str,
                            help='A single IP to be verified')
     verify_ip.add_argument('-f', '--file', type=argparse.FileType('r'),
@@ -437,6 +480,9 @@ def main():
                             help='A single domain to enumerate sub domains')
 
     args = parser.parse_args()
+
+    if args.cmd == 'scoper':
+        scoper(args.assessment_id, args.file)
 
     if args.cmd == 'verify_ip':
         verify_ip_address(args.assessment_id, args.ip, args.file)

--- a/recon/recon.py
+++ b/recon/recon.py
@@ -73,7 +73,7 @@ def scoper(assessment_id, file):
         raise ValueError("File cannot be None")
 
     file_path = file.name  # Extract filename
-    output_file = f"{assessment_id}_InScope.txt"
+    output_file = f"{assessment_id}_Scoper.txt"
 
     try:
         # Run nmap and capture output

--- a/recon/recon.py
+++ b/recon/recon.py
@@ -109,7 +109,7 @@ def scoper(assessment_id, file):
         with open(output_file, "w") as out_f:
             out_f.write(grep_result)
 
-        print(f'\n{Bcolors.OKBLUE}File was outputed in the current working directory to: {assessment_id}_Scoper.txt{Bcolors.ENDC}')
+        print(f'\n{Bcolors.OKBLUE}File was outputed in the current working directory: {assessment_id}_Scoper.txt{Bcolors.ENDC}')
 
     except subprocess.CalledProcessError as e:
         print(f"Error executing command: {e}")

--- a/recon/recon.py
+++ b/recon/recon.py
@@ -12,6 +12,9 @@ Created, in part, with funding and support from the United States Government. (s
 DM22-0416
 ____________________________________
 Examples of how to run:
+recon RVA-123 scoper -f File_With_CIDR_IPs.txt
+recon RVA-123 scoper --file File_With_CIDR_IPs.txt
+
 recon RVA123 verify_ip -i 8.8.8.8
 recon RVA123 verify_ip --ip 8.8.8.8
 recon RVA123 verify_ip -f ips.txt


### PR DESCRIPTION
## 🗣 Description ##

Added a feature to the SVT that takes a file of IPs in CIDR notation and outputs a file with a full list of single IP's. This PR satisfies issue #2 

## 💭 Motivation and context ##

This would be useful because the SVT tool does not accept IP's in CIDR notation as an input. Most scoping documents include CIDR notation and need to be converted to single IP's in order to work with SVT.

## 🧪 Testing ##

Ran the SVT in Kali Linux. 
Ran the SVT tool with the command: 
$ recon Assessment_ID scoper --file CIDRIPs.txt

The CIDRIPs.txt file was inputed by the SVT and successfully outputted a file with single IP's.


## ✅ Pre-approval checklist ##

- [x] A scoper feature built into the SVT and is added into the options of flags to run
- [x] The SVT successfully takes the input of a file of IP's in CIDR notation and outputs a file of single IP's to use.
- [x] Updated spelling errors in recon.py example commands
- [x] Fixed issue with subdomains syntax in README

## ✅ Pre-merge checklist ##

- [ ] Review.
- [ ] Finalize version.
